### PR TITLE
Add input for chase ultimate rewards points rate.

### DIFF
--- a/src/components/FlightSearch.tsx
+++ b/src/components/FlightSearch.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import moment_ from "moment"
 import { LeftOutlined, RightOutlined, SearchOutlined, SwapOutlined } from "@ant-design/icons"
-import { Alert, Button, DatePicker, Form } from "antd"
+import { Alert, Button, DatePicker, Form, Input } from "antd"
 import { SearchResults } from "./SearchResults"
 import { SelectAirport } from "./SelectAirport"
 import { useAwardSearch } from "../hooks/useAwardSearch"
@@ -41,6 +41,7 @@ export const FlightSearch = () => {
         <Form.Item name="departureDate" style={{ marginRight: 5 }}><DatePicker disabledDate={(current) => current.isBefore(moment().subtract(1, "day"))} allowClear={false} /></Form.Item>
         <Button icon={<LeftOutlined />} size="small" style={{ marginRight: 5, marginTop: 5 }} onClick={() => { form.setFieldsValue({ departureDate: moment(form.getFieldValue("departureDate")).subtract("1", "day") }) }} />
         <Button icon={<RightOutlined />} size="small" style={{ marginRight: 5, marginTop: 5 }} onClick={() => { form.setFieldsValue({ departureDate: moment(form.getFieldValue("departureDate")).add("1", "day") }) }} />
+        <Form.Item name="cashToPointsRate" style={{ width: 275, marginBottom: 0 }} rules = {[{ type: "number" }]}><Input addonBefore="Chase Ultimate Rewards Rate" defaultValue={1.5} /> </Form.Item>
         <Form.Item wrapperCol={{ offset: 2, span: 3 }} style={{ marginLeft: 10 }}><Button type="primary" htmlType="submit" icon={<SearchOutlined />} loading={searchProgress.loadingQueriesKeys.length > 0}>Search</Button></Form.Item>
       </Form>
 

--- a/src/hooks/useAwardSearch.tsx
+++ b/src/hooks/useAwardSearch.tsx
@@ -58,12 +58,13 @@ export const useAwardSearch = (searchQuery: SearchQuery): AwardSearchProgress =>
     meta: scraperQuery,
   })))
 
+  const cashToPointsRate = searchQuery.cashToPointsRate ?? 1.5
   // Take the results and do final calculations (like merging like flights' details and merging amenities/fares)
   const flights = React.useMemo(() => {
     const ret = scraperResults.map((flight) => reduceToBestFarePerCabin(flight))
     return mergeFlightsByFlightNo(ret)
       .map((flight) => removeCashFaresFromUnsupportedAirlines(flight))
-      .map((flight) => convertCashToMilesForCashOnlyScrapers(flight))
+      .map((flight) => convertCashToMilesForCashOnlyScrapers(flight, cashToPointsRate))
       .map((flight) => reduceToBestFarePerCabin(flight))
       .map((flight) => calculateAmenities(flight))
       .map((flight) => calculateSaverAwards(flight))
@@ -149,12 +150,12 @@ const removeCashFaresFromUnsupportedAirlines = (flight: FlightWithFares): Flight
   })
 })
 
-const convertCashToMilesForCashOnlyScrapers = (flight: FlightWithFares) => ({
+const convertCashToMilesForCashOnlyScrapers = (flight: FlightWithFares, cashToPointsRate: number) => ({
   ...flight,
   fares: flight.fares.map((fare) => {
     if (!scraperConfig.scrapers.find((scraper) => scraper.name === fare.scraper)?.cashOnlyFares)
       return fare
-    return { ...fare, miles: (fare.cash * 100) / 1.5, cash: 0 }
+    return { ...fare, miles: (fare.cash * 100) / cashToPointsRate, cash: 0 }
   })
 })
 

--- a/src/types/scrapers.d.ts
+++ b/src/types/scrapers.d.ts
@@ -51,6 +51,7 @@ export type SearchQuery = {
   origins: string[]
   destinations: string[]
   departureDate: string
+  cashToPointsRate: number
 }
 
 declare type Airport = {


### PR DESCRIPTION
As someone who has a CSP, being able to change this on the fly to 1.25 will be nice.

However, without setting up the backend browserless instance properly (I wasn't sure about set-up), this is an untested change.

<img width="600" alt="image" src="https://user-images.githubusercontent.com/12629797/180923160-afd89e8a-457e-4404-8061-68879ecea942.png">
Example of how it looks ^.